### PR TITLE
Removed double 'haskore' at stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -16,7 +16,6 @@ extra-deps: [
   , midi-0.2.1.5
   , non-negative-0.1.1
   , utility-ht-0.0.11
-  , haskore-0.2.0.7
   , explicit-exception-0.1.7.3
   , monoid-transformer-0.0.3
   , data-accessor-0.2.2.6


### PR DESCRIPTION
Removed on of the two 'haskore' references at 'extra-deps' that was causing 'stack build' error